### PR TITLE
Added a script to create a refresh token using PKCE flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "update-jekyll-config": "node scripts/update-jekyll-config.js",
     "build": "node scripts/build.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "dropbox-auth": "node scripts/dropbox-auth.js"
   },
   "repository": {
     "type": "git",

--- a/scripts/dropbox-auth.js
+++ b/scripts/dropbox-auth.js
@@ -1,0 +1,50 @@
+const readline = require('readline');
+const crypto = require("crypto");
+const fetch = require("cross-fetch");
+const DROPBOX_APP_ID = "1k72qtj2uesah0u";
+const DROPBOX_AUTH_CODE_URL = "https://www.dropbox.com/oauth2/authorize";
+const DROPBOX_AUTH_TOKEN_URL = "https://api.dropboxapi.com/oauth2/token";
+const { dropboxAuthToken } = require("./services/dropbox");
+
+const base64Encode = (buffer) => {
+    return buffer.toString("base64")
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+        .replace(/=/g, '');
+}
+
+const sha256 = (buffer) => {
+    return crypto.createHash('sha256').update(buffer).digest();
+}
+
+const openAuthCodeUrl = () => {
+    const codeVerifier = base64Encode(crypto.randomBytes(32));
+    const codeChallenge = base64Encode(sha256(codeVerifier));
+    const authCodeUrl = `${DROPBOX_AUTH_CODE_URL}?client_id=${DROPBOX_APP_ID}&response_type=code&code_challenge=${codeChallenge}&code_challenge_method=S256&token_access_type=offline`
+    return [codeVerifier, authCodeUrl];
+};
+
+/**
+ * @doc: https://dropbox.tech/developers/pkce--what-and-why-
+ */
+const main = () => {
+    const rl = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout
+    });
+    console.log("Initiating Dropbox OAuth flow...");
+    const [codeVerifier, authCodeUrl] = openAuthCodeUrl();
+    console.log(`[1] Visit the following URL to get auth code: ${authCodeUrl}`);
+    rl.question("[2] Enter the auth code from [1]:\n", async (code) => {
+        const { refresh_token: refreshToken } = await dropboxAuthToken({
+            code,
+            codeVerifier,
+            grantType: "authorization_code",
+            clientId: DROPBOX_APP_ID,
+        });
+        console.log(`Generated a refresh token: ${refreshToken}`);
+        rl.close();
+    });
+};
+
+main();

--- a/scripts/services/dropbox.js
+++ b/scripts/services/dropbox.js
@@ -3,19 +3,33 @@ const DROPBOX_API_V2_URL = 'https://api.dropboxapi.com/2';
 const DROPBOX_CONTENT_API_V2_URL = 'https://content.dropboxapi.com/2';
 const DROPBOX_AUTH_URL = "https://api.dropboxapi.com/oauth2";
 
-const dropboxAuthToken = async ({ refreshToken, clientId, clientSecret, grantType  }) => {
-    const endpoint = `${DROPBOX_AUTH_URL}/token`; 
+const dropboxAuthToken = async ({ refreshToken, clientId, clientSecret, grantType, codeVerifier, code  }) => {
+    const endpoint = `${DROPBOX_AUTH_URL}/token`;
+    const searchParams = new URLSearchParams();
+    if (clientId) {
+        searchParams.set("client_id", clientId);
+    }
+    if (clientSecret) {
+        searchParams.set("client_secret", clientSecret);
+    }
+    if (refreshToken) {
+        searchParams.set("refresh_token", refreshToken);
+    }
+    if (grantType) {
+        searchParams.set("grant_type", grantType);
+    }
+    if (code) {
+        searchParams.set("code", code);
+    }
+    if (codeVerifier) {
+        searchParams.set("code_verifier", codeVerifier);
+    }
     const result = await fetch(endpoint, {
         method: "POST",
         headers: {
             "Content-Type": "application/x-www-form-urlencoded",
         },
-        body: new URLSearchParams({
-            client_id: clientId,
-            client_secret: clientSecret,
-            refresh_token: refreshToken,
-            grant_type: grantType,
-        }),
+        body: searchParams
     });
     return await result.json();
 };


### PR DESCRIPTION
Currently, one pain point when setting the repo was users need to (1) create a Dropbox app and (2) generate a long-lived token manually.

With PKCE flow, users won't be needing to create their own Dropbox app, and the added script will make the refresh token generation step a lot simpler.

![Screenshot by Dropbox Capture](https://user-images.githubusercontent.com/17169119/184039735-a14866c2-8546-428f-9909-1b781248e1c0.png)
